### PR TITLE
Clarify connections with naming, count field, and convenience field

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,3 +8,4 @@
 [libs]
 
 [options]
+suppress_comment=.*\\$FlowIssue

--- a/swapi/src/schema/__tests__/apiHelper.js
+++ b/swapi/src/schema/__tests__/apiHelper.js
@@ -25,9 +25,19 @@ describe('API Helper', () => {
   });
 
   it('Gets all pages at once', async () => {
-    var people = await getObjectsByType('people');
-    expect(people.length).to.equal(82);
-    expect(people[0].name).to.equal('Luke Skywalker');
+    var {objects, totalCount} = await getObjectsByType('people');
+    expect(objects.length).to.equal(82);
+    expect(totalCount).to.equal(82);
+    expect(objects[0].name).to.equal('Luke Skywalker');
+  });
+
+  it('Gets first page and correct count', async () => {
+    var {objects, totalCount} = await getObjectsByType('people', {first: 5});
+    // Should only fetch the first page which has 10 items
+    expect(objects.length).to.equal(10);
+    // Count should still be accurate, though
+    expect(totalCount).to.equal(82);
+    expect(objects[0].name).to.equal('Luke Skywalker');
   });
 
   it('Gets a person by ID', async () => {

--- a/swapi/src/schema/__tests__/film.js
+++ b/swapi/src/schema/__tests__/film.js
@@ -63,11 +63,11 @@ describe('Film type', async () => {
     director
     producers
     releaseDate
-    species(first:1) { edges { node { name } } }
-    starships(first:1) { edges { node { name } } }
-    vehicles(first:1) { edges { node { name } } }
-    characters(first:1) { edges { node { name } } }
-    planets(first:1) { edges { node { name } } }
+    speciesConnection(first:1) { edges { node { name } } }
+    starshipConnection(first:1) { edges { node { name } } }
+    vehicleConnection(first:1) { edges { node { name } } }
+    characterConnection(first:1) { edges { node { name } } }
+    planetConnection(first:1) { edges { node { name } } }
   }
 }`;
     var result = await swapi(query);
@@ -78,11 +78,11 @@ describe('Film type', async () => {
       director: 'George Lucas',
       producers: [ 'Gary Kurtz', 'Rick McCallum' ],
       releaseDate: '1977-05-25',
-      species: { edges: [ { node: { name: 'Human' } } ] },
-      starships: { edges: [ { node: { name: 'CR90 corvette' } } ] },
-      vehicles: { edges: [ { node: { name: 'Sand Crawler' } } ] },
-      characters: { edges: [ { node: { name: 'Luke Skywalker' } } ] },
-      planets: { edges: [ { node: { name: 'Tatooine' } } ] }
+      speciesConnection: { edges: [ { node: { name: 'Human' } } ] },
+      starshipConnection: { edges: [ { node: { name: 'CR90 corvette' } } ] },
+      vehicleConnection: { edges: [ { node: { name: 'Sand Crawler' } } ] },
+      characterConnection: { edges: [ { node: { name: 'Luke Skywalker' } } ] },
+      planetConnection: { edges: [ { node: { name: 'Tatooine' } } ] }
     };
     expect(result.data.film).to.deep.equal(expected);
   });
@@ -94,22 +94,25 @@ describe('Film type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allFilms(first: 2) { edges { cursor, node { title } } } }`;
+    var query = `{
+      allFilms(first: 2) { edges { cursor, node { title } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allFilms.edges.map(e => e.node.title)).to.deep.equal([
-      'A New Hope',
-      'The Empire Strikes Back'
-    ]);
+    expect(result.data.allFilms.edges.map(e => e.node.title))
+      .to.deep.equal([
+        'A New Hope',
+        'The Empire Strikes Back'
+      ]);
     var nextCursor = result.data.allFilms.edges[1].cursor;
 
     var nextQuery = `{ allFilms(first: 2, after:"${nextCursor}") {
       edges { cursor, node { title } } }
     }`;
     var nextResult = await swapi(nextQuery);
-    expect(nextResult.data.allFilms.edges.map(e => e.node.title)).to.deep.equal(
-    [
-      'Return of the Jedi',
-      'The Phantom Menace',
-    ]);
+    expect(nextResult.data.allFilms.edges.map(e => e.node.title))
+      .to.deep.equal([
+        'Return of the Jedi',
+        'The Phantom Menace',
+      ]);
   });
 });

--- a/swapi/src/schema/__tests__/person.js
+++ b/swapi/src/schema/__tests__/person.js
@@ -66,10 +66,10 @@ describe('Person type', async () => {
     mass
     skinColor
     homeworld { name }
-    films(first:1) { edges { node { title } } }
+    filmConnection(first:1) { edges { node { title } } }
     species { name }
-    starships(first:1) { edges { node { name } } }
-    vehicles(first:1) { edges { node { name } } }
+    starshipConnection(first:1) { edges { node { name } } }
+    vehicleConnection(first:1) { edges { node { name } } }
   }
 }`;
     var result = await swapi(query);
@@ -83,10 +83,10 @@ describe('Person type', async () => {
       mass: 77,
       skinColor: 'fair',
       homeworld: { name: 'Tatooine' },
-      films: { edges: [{ node: { title: 'A New Hope' } }] },
+      filmConnection: { edges: [{ node: { title: 'A New Hope' } }] },
       species: null,
-      starships: { edges: [{ node: { name: 'X-wing' } }] },
-      vehicles: { edges: [{ node: { name: 'Snowspeeder' } }] },
+      starshipConnection: { edges: [{ node: { name: 'X-wing' } }] },
+      vehicleConnection: { edges: [{ node: { name: 'Snowspeeder' } }] },
     };
     expect(result.data.person).to.deep.equal(expected);
   });
@@ -98,23 +98,26 @@ describe('Person type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allPeople(first: 2) { edges { cursor, node { name } } } }`;
+    var query = `{
+      allPeople(first: 2) { edges { cursor, node { name } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allPeople.edges.map(e => e.node.name)).to.deep.equal([
-      'Luke Skywalker',
-      'C-3PO',
-    ]);
+    expect(result.data.allPeople.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Luke Skywalker',
+        'C-3PO',
+      ]);
     var nextCursor = result.data.allPeople.edges[1].cursor;
 
     var nextQuery = `{ allPeople(first: 2, after:"${nextCursor}") {
       edges { cursor, node { name } } }
     }`;
     var nextResult = await swapi(nextQuery);
-    expect(nextResult.data.allPeople.edges.map(e => e.node.name)).to.deep.equal(
-    [
-      'R2-D2',
-      'Darth Vader',
-    ]);
+    expect(nextResult.data.allPeople.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'R2-D2',
+        'Darth Vader',
+      ]);
   });
 
   describe('Edge cases', () => {

--- a/swapi/src/schema/__tests__/planet.js
+++ b/swapi/src/schema/__tests__/planet.js
@@ -66,20 +66,20 @@ describe('Planet type', async () => {
     climates
     terrains
     surfaceWater
-    residents(first:1) { edges { node { name } } }
-    films(first:1) { edges { node { title } } }
+    residentConnection(first:1) { edges { node { name } } }
+    filmConnection(first:1) { edges { node { title } } }
   }
 }`;
     var result = await swapi(query);
     var expected = {
       climates: [ 'arid' ],
       diameter: 10465,
-      films: { edges: [ { node: { title: 'A New Hope' } } ] },
+      filmConnection: { edges: [ { node: { title: 'A New Hope' } } ] },
       gravity: '1 standard',
       name: 'Tatooine',
       orbitalPeriod: 304,
       population: 200000,
-      residents: { edges: [ { node: { name: 'Luke Skywalker' } } ] },
+      residentConnection: { edges: [ { node: { name: 'Luke Skywalker' } } ] },
       rotationPeriod: 23,
       surfaceWater: 1,
       terrains: [ 'dessert' ] // [sic]
@@ -94,22 +94,25 @@ describe('Planet type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allPlanets(first: 2) { edges { cursor, node { name } } } }`;
+    var query = `{
+      allPlanets(first: 2) { edges { cursor, node { name } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allPlanets.edges.map(e => e.node.name)).to.deep.equal([
-      'Tatooine',
-      'Alderaan',
-    ]);
+    expect(result.data.allPlanets.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Tatooine',
+        'Alderaan',
+      ]);
     var nextCursor = result.data.allPlanets.edges[1].cursor;
 
     var nextQuery = `{ allPlanets(first: 2, after:"${nextCursor}") {
       edges { cursor, node { name } } }
     }`;
     var nextResult = await swapi(nextQuery);
-    expect(nextResult.data.allPlanets.edges.map(e => e.node.name)).to.deep.equal(
-    [
-      'Yavin IV',
-      'Hoth',
-    ]);
+    expect(nextResult.data.allPlanets.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Yavin IV',
+        'Hoth',
+      ]);
   });
 });

--- a/swapi/src/schema/__tests__/species.js
+++ b/swapi/src/schema/__tests__/species.js
@@ -67,8 +67,8 @@ describe('Species type', async () => {
     skinColors
     language
     homeworld { name }
-    people(first:1) { edges { node { name } } }
-    films(first:1) { edges { node { title } } }
+    personConnection(first:1) { edges { node { name } } }
+    filmConnection(first:1) { edges { node { title } } }
   }
 }`;
     var result = await swapi(query);
@@ -82,8 +82,8 @@ describe('Species type', async () => {
       homeworld: { name: 'Rodia' },
       language: 'Galatic Basic', // [sic]
       name: 'Rodian',
-      people: { edges: [ { node: { name: 'Greedo' } } ] },
-      films: { edges: [ { node: { title: 'A New Hope' } } ] },
+      personConnection: { edges: [ { node: { name: 'Greedo' } } ] },
+      filmConnection: { edges: [ { node: { title: 'A New Hope' } } ] },
       skinColors: ['green', 'blue']
     };
     expect(result.data.species).to.deep.equal(expected);
@@ -96,12 +96,15 @@ describe('Species type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allSpecies(first: 2) { edges { cursor, node { name } } } }`;
+    var query = `{
+      allSpecies(first: 2) { edges { cursor, node { name } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allSpecies.edges.map(e => e.node.name)).to.deep.equal([
-      'Human',
-      'Droid',
-    ]);
+    expect(result.data.allSpecies.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Human',
+        'Droid',
+      ]);
     var nextCursor = result.data.allSpecies.edges[1].cursor;
 
     var nextQuery = `{ allSpecies(first: 2, after:"${nextCursor}") {
@@ -109,10 +112,10 @@ describe('Species type', async () => {
     }`;
     var nextResult = await swapi(nextQuery);
     expect(nextResult.data.allSpecies.edges.map(e => e.node.name))
-    .to.deep.equal([
-      'Wookie', // [sic]
-      'Rodian'
-    ]);
+      .to.deep.equal([
+        'Wookie', // [sic]
+        'Rodian'
+      ]);
   });
 
   describe('Edge cases', () => {

--- a/swapi/src/schema/__tests__/starship.js
+++ b/swapi/src/schema/__tests__/starship.js
@@ -70,8 +70,8 @@ describe('Starship type', async () => {
     MGLT
     cargoCapacity
     consumables
-    films(first:1) { edges { node { title } } }
-    pilots(first:1) { edges { node { name } } }
+    filmConnection(first:1) { edges { node { title } } }
+    pilotConnection(first:1) { edges { node { name } } }
   }
 }`;
     var result = await swapi(query);
@@ -81,7 +81,7 @@ describe('Starship type', async () => {
       consumables: '3 years',
       costInCredits: 1000000000000,
       crew: '342,953',
-      films: { edges: [ { node: { title: 'A New Hope' } } ] },
+      filmConnection: { edges: [ { node: { title: 'A New Hope' } } ] },
       hyperdriveRating: 4,
       length: 120000,
       manufacturers: [ 'Imperial Department of Military Research', 'Sienar Fleet Systems' ],
@@ -89,7 +89,7 @@ describe('Starship type', async () => {
       model: 'DS-1 Orbital Battle Station',
       name: 'Death Star',
       passengers: '843,342',
-      pilots: { edges: [] },
+      pilotConnection: { edges: [] },
       starshipClass: 'Deep Space Mobile Battlestation'
     };
     expect(result.data.starship).to.deep.equal(expected);
@@ -102,30 +102,34 @@ describe('Starship type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allStarships(first: 2) { edges { cursor, node { name } } } }`;
+    var query = `{
+      allStarships(first: 2) { edges { cursor, node { name } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allStarships.edges.map(e => e.node.name)).to.deep.equal([
-      'CR90 corvette',
-      'Star Destroyer',
-    ]);
+    expect(result.data.allStarships.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'CR90 corvette',
+        'Star Destroyer',
+      ]);
     var nextCursor = result.data.allStarships.edges[1].cursor;
 
     var nextQuery = `{ allStarships(first: 2, after:"${nextCursor}") {
       edges { cursor, node { name } } }
     }`;
     var nextResult = await swapi(nextQuery);
-    expect(nextResult.data.allStarships.edges.map(e => e.node.name)).to.deep.equal(
-    [
-      'Sentinel-class landing craft',
-      'Death Star',
-    ]);
+    expect(nextResult.data.allStarships.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Sentinel-class landing craft',
+        'Death Star',
+      ]);
   });
 
   describe('Edge cases', () => {
     it('Returns real speed when set to not n/a', async () => {
       var query = `{ starship(starshipID: 5) { name, maxAtmospheringSpeed } }`;
       var result = await swapi(query);
-      expect(result.data.starship.name).to.equal('Sentinel-class landing craft');
+      expect(result.data.starship.name)
+        .to.equal('Sentinel-class landing craft');
       expect(result.data.starship.maxAtmospheringSpeed).to.equal(1000);
     });
   });

--- a/swapi/src/schema/__tests__/vehicle.js
+++ b/swapi/src/schema/__tests__/vehicle.js
@@ -68,8 +68,8 @@ describe('Vehicle type', async () => {
     maxAtmospheringSpeed
     cargoCapacity
     consumables
-    films(first:1) { edges { node { title } } }
-    pilots(first:1) { edges { node { name } } }
+    filmConnection(first:1) { edges { node { title } } }
+    pilotConnection(first:1) { edges { node { name } } }
   }
 }`;
     var result = await swapi(query);
@@ -84,8 +84,8 @@ describe('Vehicle type', async () => {
       model: 'Digger Crawler',
       name: 'Sand Crawler',
       passengers: '30',
-      pilots: { edges: [] },
-      films: { edges: [ { node: { title: 'A New Hope' } } ] },
+      pilotConnection: { edges: [] },
+      filmConnection: { edges: [ { node: { title: 'A New Hope' } } ] },
       vehicleClass: 'wheeled'
     };
     expect(result.data.vehicle).to.deep.equal(expected);
@@ -98,22 +98,25 @@ describe('Vehicle type', async () => {
   });
 
   it('Pagination query', async() => {
-    var query = `{ allVehicles(first: 2) { edges { cursor, node { name } } } }`;
+    var query = `{
+      allVehicles(first: 2) { edges { cursor, node { name } } }
+    }`;
     var result = await swapi(query);
-    expect(result.data.allVehicles.edges.map(e => e.node.name)).to.deep.equal([
-      'Sand Crawler',
-      'T-16 skyhopper',
-    ]);
+    expect(result.data.allVehicles.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'Sand Crawler',
+        'T-16 skyhopper',
+      ]);
     var nextCursor = result.data.allVehicles.edges[1].cursor;
 
     var nextQuery = `{ allVehicles(first: 2, after:"${nextCursor}") {
       edges { cursor, node { name } } }
     }`;
     var nextResult = await swapi(nextQuery);
-    expect(nextResult.data.allVehicles.edges.map(e => e.node.name)).to.deep.equal(
-    [
-      'X-34 landspeeder',
-      'TIE/LN starfighter',
-    ]);
+    expect(nextResult.data.allVehicles.edges.map(e => e.node.name))
+      .to.deep.equal([
+        'X-34 landspeeder',
+        'TIE/LN starfighter',
+      ]);
   });
 });

--- a/swapi/src/schema/apiHelper.js
+++ b/swapi/src/schema/apiHelper.js
@@ -61,20 +61,27 @@ function doneFetching(objects: Array<Object>, args?: ?Object): boolean {
   return objects.length >= args.first;
 }
 
+type ObjectsByType = {
+  objects: Array<Object>,
+  totalCount: number
+}
+
 /**
  * Given a type, fetch all of the pages, and join the objects together
  */
 export async function getObjectsByType(
   type: string,
   args?: ?Object
-): Promise<Array<Object>> {
+): Promise<ObjectsByType> {
   var objects = [];
+  var totalCount = 0;
   var nextUrl = `http://swapi.co/api/${type}/`;
   while (nextUrl && !doneFetching(objects, args)) {
     var pageData = await memoizeFromUrl(nextUrl);
     var parsedPageData = JSON.parse(pageData);
+    totalCount = parsedPageData.count;
     objects = objects.concat(parsedPageData.results.map(objectWithId));
     nextUrl = parsedPageData.next;
   }
-  return objects;
+  return {objects, totalCount};
 }

--- a/swapi/src/schema/connections.js
+++ b/swapi/src/schema/connections.js
@@ -8,7 +8,7 @@
  */
 
 import {
-  connectionFromPromisedArray,
+  connectionFromArray,
   connectionArgs,
   connectionDefinitions,
 } from 'graphql-relay';
@@ -16,6 +16,11 @@ import {
 import {
   getObjectFromUrl
 } from './apiHelper';
+
+import {
+  GraphQLInt,
+  GraphQLList
+} from 'graphql';
 
 import type {
   GraphQLOutputType,
@@ -32,19 +37,46 @@ export function connectionFromUrls(
   prop: string,
   type: GraphQLOutputType
 ): GraphQLFieldConfig {
-  var {connectionType} = connectionDefinitions({name: name, nodeType: type});
+  var {connectionType} = connectionDefinitions({
+    name: name,
+    nodeType: type,
+    connectionFields: () => ({
+      totalCount: {
+        type: GraphQLInt,
+        resolve: (conn) => conn.totalCount,
+        description:
+`A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example.`
+      },
+      // $FlowIssue Computed propertes
+      [prop]: {
+        type: new GraphQLList(type),
+        resolve: (conn) => conn.edges.map((edge) => edge.node),
+        description:
+`A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead.`
+      }
+    })
+  });
   return {
     type: connectionType,
     args: connectionArgs,
-    resolve: (obj, args) => {
+    resolve: async (obj, args) => {
       var promisedArray = [];
       if (obj[prop]) {
         promisedArray = obj[prop].map(getObjectFromUrl);
       }
-      return connectionFromPromisedArray(
-        Promise.all(promisedArray),
-        args
-      );
+      var array = await Promise.all(promisedArray);
+      return {
+        ...connectionFromArray(array, args),
+        totalCount: array.length
+      };
     },
   };
 }

--- a/swapi/src/schema/types/film.js
+++ b/swapi/src/schema/types/film.js
@@ -72,15 +72,31 @@ var FilmType = new GraphQLObjectType({
       description:
 `The ISO 8601 date format of film release at original creator country.`
     },
-    species: connectionFromUrls('FilmSpecies', 'species', SpeciesType),
-    starships: connectionFromUrls('FilmStarships', 'starships', StarshipType),
-    vehicles: connectionFromUrls('FilmVehicles', 'vehicles', VehicleType),
-    characters: connectionFromUrls(
+    speciesConnection: connectionFromUrls(
+      'FilmSpecies',
+      'species',
+      SpeciesType
+    ),
+    starshipConnection: connectionFromUrls(
+      'FilmStarships',
+      'starships',
+      StarshipType
+    ),
+    vehicleConnection: connectionFromUrls(
+      'FilmVehicles',
+      'vehicles',
+      VehicleType
+    ),
+    characterConnection: connectionFromUrls(
       'FilmCharacters',
       'characters',
       PersonType
     ),
-    planets: connectionFromUrls('FilmPlants', 'planets', PlanetType),
+    planetConnection: connectionFromUrls(
+      'FilmPlants',
+      'planets',
+      PlanetType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('films')

--- a/swapi/src/schema/types/person.js
+++ b/swapi/src/schema/types/person.js
@@ -91,7 +91,11 @@ person does not have hair.`
       description:
 `A planet that this person was born on or inhabits.`
     },
-    films: connectionFromUrls('PersonFilms', 'films', FilmType),
+    filmConnection: connectionFromUrls(
+      'PersonFilms',
+      'films',
+      FilmType
+    ),
     species: {
       type: SpeciesType,
       resolve: (person) => {
@@ -103,12 +107,16 @@ person does not have hair.`
       description:
 `The species that this person belongs to, or null if unknown.`
     },
-    starships: connectionFromUrls(
+    starshipConnection: connectionFromUrls(
       'PersonStarships',
       'starships',
       StarshipType
     ),
-    vehicles: connectionFromUrls('PersonVehicles', 'vehicles', VehicleType),
+    vehicleConnection: connectionFromUrls(
+      'PersonVehicles',
+      'vehicles',
+      VehicleType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('people')

--- a/swapi/src/schema/types/planet.js
+++ b/swapi/src/schema/types/planet.js
@@ -93,8 +93,16 @@ G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.`
 `The percentage of the planet surface that is naturally occuring water or bodies
 of water.`
     },
-    residents: connectionFromUrls('PlanetResidents', 'residents', PersonType),
-    films: connectionFromUrls('PlanetFilms', 'films', FilmType),
+    residentConnection: connectionFromUrls(
+      'PlanetResidents',
+      'residents',
+      PersonType
+    ),
+    filmConnection: connectionFromUrls(
+      'PlanetFilms',
+      'films',
+      FilmType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('planets')

--- a/swapi/src/schema/types/species.js
+++ b/swapi/src/schema/types/species.js
@@ -104,8 +104,16 @@ have skin.`
       description:
 `A planet that this species originates from.`
     },
-    people: connectionFromUrls('SpeciesPeople', 'people', PersonType),
-    films: connectionFromUrls('SpeciesFilms', 'films', FilmType),
+    personConnection: connectionFromUrls(
+      'SpeciesPeople',
+      'people',
+      PersonType
+    ),
+    filmConnection: connectionFromUrls(
+      'SpeciesFilms',
+      'films',
+      FilmType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('species')

--- a/swapi/src/schema/types/starship.js
+++ b/swapi/src/schema/types/starship.js
@@ -120,8 +120,16 @@ distance between our Sun (Sol) and Earth.`
 `The maximum length of time that this starship can provide consumables for its
 entire crew without having to resupply.`
     },
-    pilots: connectionFromUrls('StarshipPilots', 'pilots', PersonType),
-    films: connectionFromUrls('StarshipFilms', 'films', FilmType),
+    pilotConnection: connectionFromUrls(
+      'StarshipPilots',
+      'pilots',
+      PersonType
+    ),
+    filmConnection: connectionFromUrls(
+      'StarshipFilms',
+      'films',
+      FilmType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('starships')

--- a/swapi/src/schema/types/vehicle.js
+++ b/swapi/src/schema/types/vehicle.js
@@ -99,8 +99,16 @@ Transport".`
 `The maximum length of time that this vehicle can provide consumables for its
 entire crew without having to resupply.`
     },
-    pilots: connectionFromUrls('VehiclePilots', 'pilots', PersonType),
-    films: connectionFromUrls('VehicleFilms', 'films', FilmType),
+    pilotConnection: connectionFromUrls(
+      'VehiclePilots',
+      'pilots',
+      PersonType
+    ),
+    filmConnection: connectionFromUrls(
+      'VehicleFilms',
+      'films',
+      FilmType
+    ),
     created: createdField(),
     edited: editedField(),
     id: globalIdField('vehicles')


### PR DESCRIPTION
The connections in this repo are designed to allow efficient pagination
by associating cursors with each item in a connection:

```graphql
{
  allPeople {
    edges {
      cursor
      node {
        name
      }
    }
  }
}
```

When quickly exploring the API, though, it can be useful to have a shortcut
to just get the list of objects:

```graphql
{
  allPeople {
    people {
      name
    }
  }
}
```

While this shortcut would not allow for the efficient cursor-based pagination
that Relay and other clients might implement, it's quite convenient for browsing
the API.

To clarify naming once that shortcut is added, each field that returns a
connection is renamed:

```graphql
{
  personConnection {
    people {
      name
    }
  }
}
```

Finally, it's useful to have a total count of the number of items in each
connections, so that field is added:

```graphql
{
  personConnection(first: 5) {
    totalCount
    people {
      name
    }
  }
}
```