### PR TITLE
Fixing "Planet type Gets all properties" Test Assertions

### DIFF
--- a/src/schema/__tests__/planet.js
+++ b/src/schema/__tests__/planet.js
@@ -82,7 +82,7 @@ describe('Planet type', async () => {
       residentConnection: { edges: [ { node: { name: 'Luke Skywalker' } } ] },
       rotationPeriod: 23,
       surfaceWater: 1,
-      terrains: [ 'dessert' ] // [sic]
+      terrains: [ 'desert' ]
     };
     expect(result.data.planet).to.deep.equal(expected);
   });


### PR DESCRIPTION
Before:

```
1) Planet type Gets all properties:

      AssertionError: expected { Object (name, diameter, ...) } to deeply equal { Object (climates, diameter, ...) }
      + expected - actual

         }
         "rotationPeriod": 23
         "surfaceWater": 1
         "terrains": [
      -    "desert"
      +    "dessert"
         ]
       }
      
      at Assertion.assertEqual (node_modules/chai/lib/chai/core/assertions.js:485:19)
      at Assertion.ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at Object.callee$1$0$ (src/schema/__tests__/planet.js:87:40)
      at tryCatch (node_modules/babel-runtime/regenerator/runtime.js:72:40)
      at GeneratorFunctionPrototype.invoke [as _invoke] (node_modules/babel-runtime/regenerator/runtime.js:334:22)
      at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (node_modules/babel-runtime/regenerator/runtime.js:105:21)
      at tryCatch (node_modules/babel-runtime/regenerator/runtime.js:72:40)
      at invoke (node_modules/babel-runtime/regenerator/runtime.js:146:20)
      at node_modules/babel-runtime/regenerator/runtime.js:154:13
      at run (node_modules/core-js/modules/es6.promise.js:104:47)
      at node_modules/core-js/modules/es6.promise.js:115:28
      at flush (node_modules/core-js/modules/$.microtask.js:19:5)
```

After:

```
  55 passing (204ms)
```