### PR TITLE
remove babel dev dependency, add babel-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react": "15.3.2"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
+    "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.0",
     "babel-plugin-add-module-exports": "0.2.1",


### PR DESCRIPTION
When running `npm start` I get the error:
> You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
> Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.
> 
>     npm uninstall babel
>     npm install babel-cli

This PR changes `package.json` so that `npm start` works out of the box.