### PR TITLE
Fix broken `npm run start` by adding missing babel-cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "babel": "^6.5.2",
+    "babel-cli": "6.22.2",
     "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.0",
     "babel-plugin-add-module-exports": "0.2.1",


### PR DESCRIPTION
`npm run start` was broken, reporting:

    You have mistakenly installed the `babel` package, which is a no-op
    in Babel 6. Babel's CLI commands have been moved from the `babel`
    package to the `babel-cli` package.

Install `babel-cli`, making `npm run start` work again.