### PR TITLE
Add ability to run from static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "coveralls": "babel-node node_modules/.bin/isparta cover --root src --report lcovonly node_modules/.bin/_mocha -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "npm run download && npm run build-public",
     "download": "if [ ! -f src/api/cachedData/cache.js ]; then echo 'Downloading cache...' && node src/api/cachedData/downloadCache.js > src/api/cachedData/cache.js && echo 'Cached!'; fi;",
-    "build-public": "mkdir -p lib/public && cp src/public/* lib/public/"
+    "build-public": "scripts/build-public"
   },
   "dependencies": {
     "babel-runtime": "6.18.0",

--- a/scripts/build-public
+++ b/scripts/build-public
@@ -9,7 +9,7 @@
 
 set -e
 
-mkdir -p lib/public/api/cachedData
+mkdir -p lib/public
 
 cp src/public/*.{ico,html} lib/public/
 

--- a/scripts/build-public
+++ b/scripts/build-public
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+set -e
+
+mkdir -p lib/public/api/cachedData
+
+cp src/public/*.{ico,html} lib/public/
+
+browserify -t babelify --outfile lib/public/swapi.js src/public/swapi.js
+
+browserify \
+  --standalone Schema \
+  -t babelify \
+  --outfile lib/public/schema.js \
+  src/public/schema-proxy.js

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>SWAPI GraphQL API</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style media="screen" type="text/css">
+    body {
+      height: 100vh;
+      margin: 0;
+      overflow: hidden;
+      width: 100%;
+    }
+    #splash {
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      font-family: system, -apple-system, "San Francisco", ".SFNSDisplay-Regular", "Segoe UI", Segoe, "Segoe WP", "Helvetica Neue", helvetica, "Lucida Grande", arial, sans-serif;
+      height: 100vh;
+      justify-content: center;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="splash">
+    Loading&hellip;
+  </div>
+  <script src="swapi.js"></script>
+</body>
+</html>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4,6 +4,7 @@
   <title>SWAPI GraphQL API</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="favicon.ico">
   <style media="screen" type="text/css">
     body {
       height: 100vh;

--- a/src/public/schema-proxy.js
+++ b/src/public/schema-proxy.js
@@ -15,4 +15,4 @@ export default {
   },
 
   schema,
-}
+};

--- a/src/public/schema-proxy.js
+++ b/src/public/schema-proxy.js
@@ -1,0 +1,18 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ */
+
+import {graphql} from 'graphql';
+import schema from '../schema';
+
+export default {
+  execute(query, variables, operationName) {
+    return graphql(schema, query, null, null, variables, operationName);
+  },
+
+  schema,
+}

--- a/src/public/swapi.js
+++ b/src/public/swapi.js
@@ -1,0 +1,152 @@
+(function() {
+  'use strict';
+
+  const GRAPHIQL_VERSION = '0.8.1';
+  const PROTOCOL = getProtocol();
+  const LEGAL_PARAMETER_NAMES = ['query', 'variables', 'operationName'];
+
+  let parameters = extractURLParameters();
+
+  function getProtocol() {
+    // For ease of testing on the local filesystem, request over the network
+    // instead of trying to load (broken) links like
+    // "file://cdn.jsdelivr.net/..." etc.
+    if (window.location.protocol === 'file:') {
+      return 'https:';
+    }
+    return '';
+  }
+
+  function loadStyles(sheet) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href = PROTOCOL + sheet;
+    document.head.appendChild(link);
+  }
+
+  function loadScript(path, done) {
+    // IE-compatible asynchronous loading.
+    const script = document.createElement('script');
+    let loaded = false
+    script.onload = script.onreadystatechange = function() {
+      if (loaded) {
+        return;
+      } else if (
+        !this.readyState ||
+        this.readyState === 'loaded' ||
+        this.readyState === 'complete'
+      ) {
+        loaded = true;
+        done(path, script);
+      }
+    }
+
+    if (path.indexOf('/') === 0) {
+      script.src = PROTOCOL + path;
+    } else {
+      script.src = path;
+    }
+    document.head.appendChild(script);
+  }
+
+  function fetcher({query, variables, operationName}) {
+    if (typeof Schema !== 'undefined') {
+      return Schema.execute(query, variables, operationName);
+    } else {
+      // No schema yet, load it.
+      return new Promise((resolve, reject) => {
+        loadScript('schema.js', (path, script) => {
+          if (typeof Schema !== 'undefined') {
+            resolve(Schema.schema);
+          } else {
+            reject(new Error('schema.js did not define Schema object'));
+          }
+        });
+      });
+    }
+  }
+
+  function onEditQuery(query) {
+    updateURL({query});
+  }
+
+  function onEditVariables(variables) {
+    updateURL({variables});
+  }
+
+  function onEditOperationName(operationName) {
+    updateURL({operationName});
+  }
+
+  function updateURL(newParameters) {
+    parameters = {
+      ...parameters,
+      ...newParameters,
+    };
+    const queryString = '?' + Object.keys(parameters).map(key => (
+      encodeURIComponent(key) + '=' + encodeURIComponent(parameters[key])
+    )).join('&');
+    history.replaceState(null, null, queryString);
+  }
+
+  function extractURLParameters() {
+    const parameters = {};
+    window.location.search.slice(1).split('&').forEach(pair => {
+      const [key, value] = pair.split('=');
+      if (key && LEGAL_PARAMETER_NAMES.indexOf(key) !== -1) {
+        parameters[key] = decodeURIComponent(value);
+      }
+    });
+    return parameters;
+  }
+
+  function renderGraphiQL() {
+    const {query, variables, operationName} = parameters;
+    ReactDOM.render(
+      React.createElement(GraphiQL, {
+        fetcher,
+        onEditQuery,
+        onEditVariables,
+        onEditOperationName,
+        query,
+        variables,
+        operationName,
+      }),
+      document.body
+    );
+  }
+
+  function loadAssets(done) {
+    const styles = [
+      '//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.css',
+    ];
+    styles.forEach(loadStyles);
+
+    const scripts = {
+      fetch: '//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js',
+      graphiql: '//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.min.js',
+      react: '//cdn.jsdelivr.net/react/15.3.2/react.min.js',
+      'react-dom': '//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js',
+    };
+
+    function loaded(key) {
+      delete scripts[key];
+      if (!Object.keys(scripts).length) {
+        done();
+      }
+    }
+
+    // Ensure react-dom loads after react, and graphiql after react-dom.
+    loadScript(scripts.fetch, () => loaded('fetch'));
+    loadScript(scripts.react, () => {
+      loaded('react');
+      loadScript(scripts['react-dom'], () => {
+        loaded('react-dom');
+        loadScript(scripts.graphiql, () => loaded('graphiql'));
+      });
+    });
+  }
+
+  loadAssets(renderGraphiQL);
+})();

--- a/src/public/swapi.js
+++ b/src/public/swapi.js
@@ -1,9 +1,14 @@
-(function() {
+(function () {
   'use strict';
+
+  /* global GraphiQL: true */
+  /* global React: true */
+  /* global ReactDOM: true */
+  /* global Schema: true */
 
   const GRAPHIQL_VERSION = '0.8.1';
   const PROTOCOL = getProtocol();
-  const LEGAL_PARAMETER_NAMES = ['query', 'variables', 'operationName'];
+  const LEGAL_PARAMETER_NAMES = [ 'query', 'variables', 'operationName' ];
 
   let parameters = extractURLParameters();
 
@@ -28,19 +33,19 @@
   function loadScript(path, done) {
     // IE-compatible asynchronous loading.
     const script = document.createElement('script');
-    let loaded = false
-    script.onload = script.onreadystatechange = function() {
-      if (loaded) {
-        return;
-      } else if (
-        !this.readyState ||
-        this.readyState === 'loaded' ||
-        this.readyState === 'complete'
-      ) {
-        loaded = true;
-        done(path, script);
+    let loaded = false;
+    script.onload = script.onreadystatechange = function () {
+      if (!loaded) {
+        if (
+          !this.readyState ||
+          this.readyState === 'loaded' ||
+          this.readyState === 'complete'
+        ) {
+          loaded = true;
+          done(path, script);
+        }
       }
-    }
+    };
 
     if (path.indexOf('/') === 0) {
       script.src = PROTOCOL + path;
@@ -53,18 +58,18 @@
   function fetcher({query, variables, operationName}) {
     if (typeof Schema !== 'undefined') {
       return Schema.execute(query, variables, operationName);
-    } else {
-      // No schema yet, load it.
-      return new Promise((resolve, reject) => {
-        loadScript('schema.js', (path, script) => {
-          if (typeof Schema !== 'undefined') {
-            resolve(Schema.schema);
-          } else {
-            reject(new Error('schema.js did not define Schema object'));
-          }
-        });
-      });
     }
+
+    // No schema yet, load it.
+    return new Promise((resolve, reject) => {
+      loadScript('schema.js', () => {
+        if (typeof Schema !== 'undefined') {
+          resolve(Schema.schema);
+        } else {
+          reject(new Error('schema.js did not define Schema object'));
+        }
+      });
+    });
   }
 
   function onEditQuery(query) {
@@ -91,14 +96,14 @@
   }
 
   function extractURLParameters() {
-    const parameters = {};
+    const extractedParameters = {};
     window.location.search.slice(1).split('&').forEach(pair => {
-      const [key, value] = pair.split('=');
+      const [ key, value ] = pair.split('=');
       if (key && LEGAL_PARAMETER_NAMES.indexOf(key) !== -1) {
-        parameters[key] = decodeURIComponent(value);
+        extractedParameters[key] = decodeURIComponent(value);
       }
     });
-    return parameters;
+    return extractedParameters;
   }
 
   function renderGraphiQL() {
@@ -124,7 +129,11 @@
     styles.forEach(loadStyles);
 
     const scripts = {
-      graphiql: '//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.min.js',
+      graphiql: (
+        '//cdn.jsdelivr.net/graphiql/' +
+        GRAPHIQL_VERSION +
+        '/graphiql.min.js'
+      ),
       react: '//cdn.jsdelivr.net/react/15.3.2/react.min.js',
       'react-dom': '//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js',
     };
@@ -147,4 +156,4 @@
   }
 
   loadAssets(renderGraphiQL);
-})();
+}());

--- a/src/public/swapi.js
+++ b/src/public/swapi.js
@@ -1,3 +1,11 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ */
+
 (function () {
   'use strict';
 

--- a/src/public/swapi.js
+++ b/src/public/swapi.js
@@ -124,7 +124,6 @@
     styles.forEach(loadStyles);
 
     const scripts = {
-      fetch: '//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js',
       graphiql: '//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.min.js',
       react: '//cdn.jsdelivr.net/react/15.3.2/react.min.js',
       'react-dom': '//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js',
@@ -138,7 +137,6 @@
     }
 
     // Ensure react-dom loads after react, and graphiql after react-dom.
-    loadScript(scripts.fetch, () => loaded('fetch'));
     loadScript(scripts.react, () => {
       loaded('react');
       loadScript(scripts['react-dom'], () => {

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -10,7 +10,6 @@ import express from 'express';
 import graphqlHTTP from 'express-graphql';
 import swapiSchema from '../schema';
 
-
 const app = express();
 
 // Requests to /graphql redirect to /


### PR DESCRIPTION
Consists of:

- Simple index.html file.
- Main app bundle that loads dependencies ("react", "react-dom", "graphiql") and renders GraphiQL.
- "schema" bundle that exposes the app schema, "graphql" executor, and cached data; this is loaded separately from within the GraphiQL fetcher callback.

The main app bundle is about 56KB in size (15KB gzipped) and the schema/data bundle is 1.0MB (152KB gzipped).

I'll have follow-up commits to this, including a script that actually deploys to the gh-pages branch, but first I have to investigating whether there'll be any conflict with our existing gh-pages for graphql.github.io.