### PR TITLE
Add deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Uses:
 * [express-graphql](https://github.com/graphql/express-graphql) - to provide HTTP access to GraphQL.
 * [GraphiQL](https://github.com/graphql/graphiql) - for easy exploration of this GraphQL server.
 
+Try it out at http://graphql.github.io/swapi-graphql/.
+
 ## Getting Started
 
 Install dependencies with

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "coveralls": "babel-node node_modules/.bin/isparta cover --root src --report lcovonly node_modules/.bin/_mocha -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "npm run download && npm run build-public",
     "download": "if [ ! -f src/api/cachedData/cache.js ]; then echo 'Downloading cache...' && node src/api/cachedData/downloadCache.js > src/api/cachedData/cache.js && echo 'Cached!'; fi;",
-    "build-public": "scripts/build-public"
+    "build-public": "scripts/build-public",
+    "deploy": "scripts/build-public && scripts/deploy-public"
   },
   "dependencies": {
     "babel-runtime": "6.18.0",

--- a/scripts/deploy-public
+++ b/scripts/deploy-public
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+set -e
+
+HEAD=`git rev-parse --short HEAD`
+PARENT=`git rev-parse gh-pages 2> /dev/null` || {
+  echo 'No gh-pages branch found.'
+  echo 'Fetch from upstream and then set up a local tracking branch:'
+  echo
+  echo '  git fetch origin'
+  echo '  git branch --track gh-pages origin/gh-pages'
+  echo
+  exit 1
+}
+
+echo "Preparing index based on:"
+ls lib/public/*
+git update-index --add lib/public/*
+
+TREE=`git write-tree --prefix=lib/public`
+echo "Wrote tree object: $TREE"
+
+echo "Reseting index to former state."
+git reset lib/public
+
+COMMIT=`git commit-tree $TREE -p $PARENT -m "Build gh-pages from $HEAD"`
+echo "Wrote commit object: $COMMIT"
+
+ABBREV=`git rev-parse --short $COMMIT`
+echo "Updating gh-pages branch to point at $ABBREV."
+git update-ref refs/heads/gh-pages $COMMIT $PARENT
+
+echo
+echo "New build committed to gh-pages branch ($ABBREV)."
+echo 'Publish it with:'
+echo
+echo '    git push origin gh-pages:gh-pages'
+echo


### PR DESCRIPTION
This runs the static build then commits the result to the `gh-pages` branch.

Once pushed, it will be live at: http://graphql.github.io/swapi-graphql

I checked how this works with our other organization repos. It works fine for the main graphql.github.io repo to write the files into the root of domain, and other repos will wind up in sub-directories; as long as the directory names don't conflict, everything should be fine.