### PR TITLE
Clarify port number in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,4 @@ A local express server is in `./server`. It can be run with:
 npm start
 ```
 
-A GraphiQL instance will be opened at http://localhost:8080/ to
-explore the API.
+A GraphiQL instance will be opened at http://localhost:8080/ (or similar; the actual port number will be printed to the console) to explore the API.


### PR DESCRIPTION
When you `npm run start`, you actually get a semi-randomly-assigned port number and will see it in the console like so:

    Listening at http://localhost:51086

You'll get a different port number each time; on three runs, I got 51086, 51364 and 51525.