### PR TITLE
Shorten demo URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uses:
 * [express-graphql](https://github.com/graphql/express-graphql) - to provide HTTP access to GraphQL.
 * [GraphiQL](https://github.com/graphql/graphiql) - for easy exploration of this GraphQL server.
 
-Try it out at http://graphql.github.io/swapi-graphql/.
+Try it out at: http://graphql.org/swapi-graphql
 
 ## Getting Started
 


### PR DESCRIPTION
If you go to graphql.github.io you're going to get redirected anyway, so we may as well use the shorter link and avoid the extra hop.