### PR TITLE
Fix `npm run watch`

### DIFF
--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -131,6 +131,7 @@ function runTests(filepaths) {
   console.log('\nRunning Tests');
 
   return exec('mocha', [
+    '--compilers', 'js:babel-register',
     '--reporter', 'progress',
     '--require', 'scripts/mocha-bootload'
   ].concat(


### PR DESCRIPTION
Was choking on ES6 stuff while running tests, but no longer so.