### PR TITLE
Perform download with babel-node

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -4,6 +4,6 @@ set -e
 
 if [ ! -s src/api/cachedData/cache.js ]; then
   echo 'Downloading cache...'
-  node src/api/cachedData/downloadCache.js > src/api/cachedData/cache.js
+  babel-node src/api/cachedData/downloadCache.js > src/api/cachedData/cache.js
   echo 'Cached!'
 fi


### PR DESCRIPTION
This should allow the `npm run download` to work on a wider range of `node` versions (ie. lacking `let`/`const` support etc).

Closes: https://github.com/graphql/swapi-graphql/issues/50