### PR TITLE
Use fragments for re-use in specs

### DIFF
--- a/src/schema/__tests__/film.js
+++ b/src/schema/__tests__/film.js
@@ -13,19 +13,23 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allFilmProperties = `
-  title
-  episodeID
-  openingCrawl
-  director
-  producers
-  releaseDate
-  speciesConnection(first:1) { edges { node { name } } }
-  starshipConnection(first:1) { edges { node { name } } }
-  vehicleConnection(first:1) { edges { node { name } } }
-  characterConnection(first:1) { edges { node { name } } }
-  planetConnection(first:1) { edges { node { name } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllFilmProperties on Film {
+      director
+      episodeID
+      openingCrawl
+      producers
+      releaseDate
+      title
+      characterConnection(first:1) { edges { node { name } } }
+      planetConnection(first:1) { edges { node { name } } }
+      speciesConnection(first:1) { edges { node { name } } }
+      starshipConnection(first:1) { edges { node { name } } }
+      vehicleConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Film type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -68,12 +72,11 @@ describe('Film type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  film(filmID: 1) {
-    ${allFilmProperties}
-  }
-}`;
+    const query = getDocument(`{
+      film(filmID: 1) {
+        ...AllFilmProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       title: 'A New Hope',
@@ -92,7 +95,9 @@ describe('Film type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allFilms { edges { cursor, node { ${allFilmProperties} } } } }`;
+    const query = getDocument(
+      '{ allFilms { edges { cursor, node { ...AllFilmProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allFilms.edges.length).to.equal(6);
   });

--- a/src/schema/__tests__/person.js
+++ b/src/schema/__tests__/person.js
@@ -13,21 +13,25 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allPersonProperties = `
-  name
-  birthYear
-  eyeColor
-  gender
-  hairColor
-  height
-  mass
-  skinColor
-  homeworld { name }
-  filmConnection(first:1) { edges { node { title } } }
-  species { name }
-  starshipConnection(first:1) { edges { node { name } } }
-  vehicleConnection(first:1) { edges { node { name } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllPersonProperties on Person {
+      birthYear
+      eyeColor
+      gender
+      hairColor
+      height
+      homeworld { name }
+      mass
+      name
+      skinColor
+      species { name }
+      filmConnection(first:1) { edges { node { title } } }
+      starshipConnection(first:1) { edges { node { name } } }
+      vehicleConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Person type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -70,12 +74,11 @@ describe('Person type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  person(personID: 1) {
-    ${allPersonProperties}
-  }
-}`;
+    const query = getDocument(`{
+      person(personID: 1) {
+        ...AllPersonProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       name: 'Luke Skywalker',
@@ -96,7 +99,9 @@ describe('Person type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allPeople { edges { cursor, node { ${allPersonProperties} } } } }`;
+    const query = getDocument(
+      '{ allPeople { edges { cursor, node { ...AllPersonProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allPeople.edges.length).to.equal(82);
   });

--- a/src/schema/__tests__/planet.js
+++ b/src/schema/__tests__/planet.js
@@ -13,19 +13,23 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allPlanetProperties = `
-  name
-  diameter
-  rotationPeriod
-  orbitalPeriod
-  gravity
-  population
-  climates
-  terrains
-  surfaceWater
-  residentConnection(first:1) { edges { node { name } } }
-  filmConnection(first:1) { edges { node { title } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllPlanetProperties on Planet {
+      climates
+      diameter
+      gravity
+      name
+      orbitalPeriod
+      population
+      rotationPeriod
+      surfaceWater
+      terrains
+      filmConnection(first:1) { edges { node { title } } }
+      residentConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Planet type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -68,12 +72,11 @@ describe('Planet type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  planet(planetID: 1) {
-    ${allPlanetProperties}
-  }
-}`;
+    const query = getDocument(`{
+      planet(planetID: 1) {
+        ...AllPlanetProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       climates: [ 'arid' ],
@@ -92,7 +95,9 @@ describe('Planet type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allPlanets { edges { cursor, node { ${allPlanetProperties} } } } }`;
+    const query = getDocument(
+      '{ allPlanets { edges { cursor, node { ...AllPlanetProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allPlanets.edges.length).to.equal(60);
   });

--- a/src/schema/__tests__/species.js
+++ b/src/schema/__tests__/species.js
@@ -13,20 +13,24 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allSpeciesProperies = `
-  name
-  classification
-  designation
-  averageHeight
-  averageLifespan
-  eyeColors
-  hairColors
-  skinColors
-  language
-  homeworld { name }
-  personConnection(first:1) { edges { node { name } } }
-  filmConnection(first:1) { edges { node { title } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllSpeciesProperties on Species {
+      averageHeight
+      averageLifespan
+      classification
+      designation
+      eyeColors
+      hairColors
+      homeworld { name }
+      language
+      name
+      skinColors
+      filmConnection(first:1) { edges { node { title } } }
+      personConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Species type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -69,12 +73,11 @@ describe('Species type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  species(speciesID: 4) {
-    ${allSpeciesProperies}
-  }
-}`;
+    const query = getDocument(`{
+      species(speciesID: 4) {
+        ...AllSpeciesProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       averageHeight: 170,
@@ -94,7 +97,9 @@ describe('Species type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allSpecies { edges { cursor, node { ${allSpeciesProperies} } } } }`;
+    const query = getDocument(
+      '{ allSpecies { edges { cursor, node { ...AllSpeciesProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allSpecies.edges.length).to.equal(37);
   });

--- a/src/schema/__tests__/starship.js
+++ b/src/schema/__tests__/starship.js
@@ -13,23 +13,27 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allStarshipProperties = `
-  name
-  model
-  starshipClass
-  manufacturers
-  costInCredits
-  length
-  crew
-  passengers
-  maxAtmospheringSpeed
-  hyperdriveRating
-  MGLT
-  cargoCapacity
-  consumables
-  filmConnection(first:1) { edges { node { title } } }
-  pilotConnection(first:1) { edges { node { name } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllStarshipProperties on Starship {
+      MGLT
+      cargoCapacity
+      consumables
+      costInCredits
+      crew
+      hyperdriveRating
+      length
+      manufacturers
+      maxAtmospheringSpeed
+      model
+      name
+      passengers
+      starshipClass
+      filmConnection(first:1) { edges { node { title } } }
+      pilotConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Starship type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -72,12 +76,11 @@ describe('Starship type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  starship(starshipID: 9) {
-    ${allStarshipProperties}
-  }
-}`;
+    const query = getDocument(`{
+      starship(starshipID: 9) {
+        ...AllStarshipProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       MGLT: 10,
@@ -100,7 +103,9 @@ describe('Starship type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allStarships { edges { cursor, node { ${allStarshipProperties} } } } }`;
+    const query = getDocument(
+      '{ allStarships { edges { cursor, node { ...AllStarshipProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allStarships.edges.length).to.equal(36);
   });

--- a/src/schema/__tests__/vehicle.js
+++ b/src/schema/__tests__/vehicle.js
@@ -13,21 +13,25 @@ import { swapi } from './swapi';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /* eslint-disable max-len */
 
-const allVehicleProperties = `
-  name
-  model
-  vehicleClass
-  manufacturers
-  costInCredits
-  length
-  crew
-  passengers
-  maxAtmospheringSpeed
-  cargoCapacity
-  consumables
-  filmConnection(first:1) { edges { node { title } } }
-  pilotConnection(first:1) { edges { node { name } } }
-`;
+function getDocument(query) {
+  return `${query}
+    fragment AllVehicleProperties on Vehicle {
+      cargoCapacity
+      consumables
+      costInCredits
+      crew
+      length
+      manufacturers
+      maxAtmospheringSpeed
+      model
+      name
+      passengers
+      vehicleClass
+      filmConnection(first:1) { edges { node { title } } }
+      pilotConnection(first:1) { edges { node { name } } }
+    }
+  `;
+}
 
 describe('Vehicle type', async () => {
   it('Gets an object by SWAPI ID', async () => {
@@ -70,12 +74,11 @@ describe('Vehicle type', async () => {
   });
 
   it('Gets all properties', async () => {
-    const query = `
-{
-  vehicle(vehicleID: 4) {
-    ${allVehicleProperties}
-  }
-}`;
+    const query = getDocument(`{
+      vehicle(vehicleID: 4) {
+        ...AllVehicleProperties
+      }
+    }`);
     const result = await swapi(query);
     const expected = {
       cargoCapacity: 50000,
@@ -96,7 +99,9 @@ describe('Vehicle type', async () => {
   });
 
   it('All objects query', async() => {
-    const query = `{ allVehicles { edges { cursor, node { ${allVehicleProperties} } } } }`;
+    const query = getDocument(
+      '{ allVehicles { edges { cursor, node { ...AllVehicleProperties } } } }'
+    );
     const result = await swapi(query);
     expect(result.data.allVehicles.edges.length).to.equal(39);
   });


### PR DESCRIPTION
This is still using string interpolation to build the document, but fragments are "the right way" to share selections across queries, so this is better.

Follow-up to: https://github.com/graphql/swapi-graphql/pull/87