### PR TITLE
Fix download on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cover": "babel-node node_modules/.bin/isparta cover --root src --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",
     "coveralls": "babel-node node_modules/.bin/isparta cover --root src --report lcovonly node_modules/.bin/_mocha -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "npm run download && npm run build-public",
-    "download": "sh scripts/download",
+    "download": "node scripts/download.js",
     "build-public": "scripts/build-public",
     "deploy": "scripts/build-public && scripts/deploy-public",
     "pretty": "node scripts/pretty.js",

--- a/scripts/download
+++ b/scripts/download
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-if [ ! -s src/api/cachedData/cache.js ]; then
-  echo 'Downloading cache...'
-  babel-node src/api/cachedData/downloadCache.js > src/api/cachedData/cache.js
-  echo 'Cached!'
-fi

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -5,14 +5,17 @@ fs.stat('./src/api/cachedData/cache.js', err => {
   if (err !== null && err.code === 'ENOENT') {
     const cachePath = 'src/api/cachedData/cache.js';
     console.log('Downloading cache...');
-    exec(`babel-node src/api/cachedData/downloadCache.js > ${cachePath}`, error => {
-      if (error) {
-        // delete any invalid cache file that may have been created
-        fs.unlink(cachePath, () => { });
-        console.warn(error.toString());
-      } else {
-        console.log('Cached!');
-      }
-    });
+    exec(
+      `babel-node src/api/cachedData/downloadCache.js > ${cachePath}`,
+      error => {
+        if (error) {
+          // delete any invalid cache file that may have been created
+          fs.unlink(cachePath, () => {});
+          console.warn(error.toString());
+        } else {
+          console.log('Cached!');
+        }
+      },
+    );
   }
 });

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -5,15 +5,14 @@ fs.stat('./src/api/cachedData/cache.js', err => {
   if (err !== null && err.code === 'ENOENT') {
     const cachePath = 'src/api/cachedData/cache.js';
     console.log('Downloading cache...');
-    exec(`babel-node src/api/cachedData/downloadCache.js > ${cachePath}`,
-      error => {
-        if (error) {
-          // delete any invalid cache file that may have been created
-          fs.unlink(cachePath, () => {});
-          console.warn(error.toString());
-        } else {
-          console.log('Cached!');
-        }
-      });
+    exec(`babel-node src/api/cachedData/downloadCache.js > ${cachePath}`, error => {
+      if (error) {
+        // delete any invalid cache file that may have been created
+        fs.unlink(cachePath, () => { });
+        console.warn(error.toString());
+      } else {
+        console.log('Cached!');
+      }
+    });
   }
 });

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -1,0 +1,19 @@
+const exec = require('child_process').exec;
+const fs = require('fs');
+
+fs.stat('./src/api/cachedData/cache.js', err => {
+  if (err !== null && err.code === 'ENOENT') {
+    const cachePath = 'src/api/cachedData/cache.js';
+    console.log('Downloading cache...');
+    exec(`babel-node src/api/cachedData/downloadCache.js > ${cachePath}`,
+      error => {
+        if (error) {
+          // delete any invalid cache file that may have been created
+          fs.unlink(cachePath, () => {});
+          console.warn(error.toString());
+        } else {
+          console.log('Cached!');
+        }
+      });
+  }
+});


### PR DESCRIPTION
This should resolve #16 to allow cache downloading to work on windows and hopefully any other OS. It moves the download/cache task from a shell script to js.