### PR TITLE
Add union type

### DIFF
--- a/doc/example_queries/09_union.graphql
+++ b/doc/example_queries/09_union.graphql
@@ -1,0 +1,16 @@
+{
+  allMachines {
+    machines {
+      ... on Vehicle {
+        id,
+        name,
+        vehicleClass
+      },
+      ... on Starship {
+        id,
+        name,
+        starshipClass
+      }
+    }
+  }
+}

--- a/src/schema/apiHelper.js
+++ b/src/schema/apiHelper.js
@@ -32,6 +32,14 @@ export async function getObjectFromUrl(url: string): Promise<Object> {
 }
 
 /**
+ * Given an object URL, return the Swapi type from it
+ * @param url
+ */
+export function getSwapiTypeFromUrl(url: string): string {
+  return url.split('/')[4];
+}
+
+/**
  * Given a type and ID, get the object with the ID.
  */
 export async function getObjectFromTypeAndId(

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -34,14 +34,14 @@ import { swapiTypeToGraphQLType, nodeField } from './relayNode';
  * usable on non-union elements).
  */
 function rootFieldByID(idName, swapiType) {
-  const type = swapiTypeToGraphQLType(swapiType);
+  const graphQLType = swapiTypeToGraphQLType(swapiType);
   const argDefs = {};
   argDefs.id = { type: GraphQLID };
-  if (!(type instanceof GraphQLUnionType)) {
+  if (!(graphQLType instanceof GraphQLUnionType)) {
     argDefs[idName] = { type: GraphQLID };
   }
   return {
-    type: swapiTypeToGraphQLType(swapiType),
+    type: graphQLType,
     args: argDefs,
     resolve: (_, args) => {
       if (!(swapiType instanceof GraphQLUnionType) && args[idName] !== undefined && args[idName] !== null) {

--- a/src/schema/relayNode.js
+++ b/src/schema/relayNode.js
@@ -23,6 +23,7 @@ export function swapiTypeToGraphQLType(swapiType: string): GraphQLObjectType {
   const SpeciesType = require('./types/species').default;
   const StarshipType = require('./types/starship').default;
   const VehicleType = require('./types/vehicle').default;
+  const MachineType = require('./types/machine').default;
 
   switch (swapiType) {
     case 'films':
@@ -37,6 +38,8 @@ export function swapiTypeToGraphQLType(swapiType: string): GraphQLObjectType {
       return VehicleType;
     case 'species':
       return SpeciesType;
+    case 'machines':
+      return MachineType;
     default:
       throw new Error('Unrecognized type `' + swapiType + '`.');
   }

--- a/src/schema/relayNode.js
+++ b/src/schema/relayNode.js
@@ -45,6 +45,27 @@ export function swapiTypeToGraphQLType(swapiType: string): GraphQLObjectType {
   }
 }
 
+/**
+ * Given a GraphQL type, return the corresponding SWAPI type
+ */
+export function graphQLTypeToSwapiType(graphQLType: GraphQLObjectType): string {
+  const typeMap = {
+    'Film': 'films',
+    'Person': 'people',
+    'Planet': 'planets',
+    'Starship': 'starships',
+    'Vehicle': 'vehicles',
+    'Species': 'species',
+    'Machine': 'machines',
+  };
+
+  if (graphQLType.name in typeMap) {
+    return typeMap[graphQLType.name];
+  } else {
+    throw new Error('Unrecognized type `' + graphQLType.name + '`.');
+  }
+}
+
 const { nodeInterface, nodeField } = nodeDefinitions(
   globalId => {
     const { type, id } = fromGlobalId(globalId);

--- a/src/schema/types/machine.js
+++ b/src/schema/types/machine.js
@@ -1,0 +1,42 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ */
+
+import {
+  GraphQLUnionType
+} from 'graphql';
+
+import { getSwapiTypeFromUrl } from '../apiHelper';
+
+import VehicleType from './vehicle';
+import StarshipType from './starship';
+
+/**
+ * GraphQL equivalent of every "machine" in the SW univers (from SWAPI)
+ */
+const MachineType = new GraphQLUnionType({
+  name: 'Machine',
+  types: [VehicleType, StarshipType],
+  resolveType(value) {
+
+    const swapiType = getSwapiTypeFromUrl(value.url);
+
+    switch (swapiType) {
+      case 'vehicles':
+        return VehicleType;
+      case 'starships':
+        return StarshipType;
+      default:
+        throw new Error('Type `' + swapiType + '` not in Machine type.');
+    }
+
+  },
+  description: 'Union of Vehicle and Starship : every available machine'
+});
+
+export default MachineType;


### PR DESCRIPTION
To be able to test the union on swapi-graphql I've added a new `MachineType` type.

Machine is a union of `VehicleType` and `StarshipType`.
It comes with the `machine` and `allMachines` queries.

I'm not sure about the relevance of the name `machine`, so feel free to suggest an other name.