### PR TITLE
Standardize types between vehicles and starships

### DIFF
--- a/src/schema/types/starship.js
+++ b/src/schema/types/starship.js
@@ -56,7 +56,7 @@ Battlestation"`,
       description: 'The manufacturers of this starship.',
     },
     costInCredits: {
-      type: GraphQLFloat,
+      type: GraphQLInt,
       resolve: ship => convertToNumber(ship.cost_in_credits),
       description: 'The cost of this starship new, in galactic credits.',
     },
@@ -96,7 +96,7 @@ the difference in speed of starships. We can assume it is similar to AU, the
 distance between our Sun (Sol) and Earth.`,
     },
     cargoCapacity: {
-      type: GraphQLFloat,
+      type: GraphQLInt,
       resolve: ship => convertToNumber(ship.cargo_capacity),
       description:
         'The maximum number of kilograms that this starship can transport.',

--- a/src/schema/types/starship.js
+++ b/src/schema/types/starship.js
@@ -56,7 +56,7 @@ Battlestation"`,
       description: 'The manufacturers of this starship.',
     },
     costInCredits: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       resolve: ship => convertToNumber(ship.cost_in_credits),
       description: 'The cost of this starship new, in galactic credits.',
     },
@@ -96,7 +96,7 @@ the difference in speed of starships. We can assume it is similar to AU, the
 distance between our Sun (Sol) and Earth.`,
     },
     cargoCapacity: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       resolve: ship => convertToNumber(ship.cargo_capacity),
       description:
         'The maximum number of kilograms that this starship can transport.',

--- a/src/schema/types/vehicle.js
+++ b/src/schema/types/vehicle.js
@@ -57,7 +57,7 @@ Transport".`,
       description: 'The manufacturers of this vehicle.',
     },
     costInCredits: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       resolve: vehicle => convertToNumber(vehicle.cost_in_credits),
       description: 'The cost of this vehicle new, in Galactic Credits.',
     },
@@ -82,7 +82,7 @@ Transport".`,
       description: 'The maximum speed of this vehicle in atmosphere.',
     },
     cargoCapacity: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       resolve: ship => convertToNumber(ship.cargo_capacity),
       description:
         'The maximum number of kilograms that this vehicle can transport.',


### PR DESCRIPTION
There is an inconsistency in types between `starship` and `vehicle`.
The `cargoCapacity` and `costInCredits` are typed as float for `starship` and as int for `vehicle`.

This PR will standardize the types between `starship` and `vehicle` and change those fields type to be float.

In fact, those values are int but the cargo capacity of the Death Star is too big for an int, so to ensure that the tests passes, we have to use float.