### PR TITLE
deploy build script, fix path for public schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "download": "babel-node scripts/download.js cache/data.json",
     "build-public": "browserify --standalone Schema -t babelify --outfile public/schema.js src/schema-proxy.js",
     "serve-public": "babel-node scripts/serve-public",
-    "deploy": "scripts/build-public && scripts/deploy-public",
+    "deploy": "yarn run build-public && scripts/deploy-public",
     "prettier": "prettier --write 'src/**/*.js'",
     "print-schema": "babel-node scripts/print-schema.js",
     "store-schema": "babel-node scripts/store-schema.js"

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
   <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/graphiql@0.11.11/graphiql.min.js"></script>
-  <script src="schema.js"></script>
+  <script src="/swapi-graphql/schema.js"></script>
   <script>
       // Parse the search string to get url parameters.
       var search = window.location.search;


### PR DESCRIPTION
this makes permanent a fix for serving up schema.js across the github.io and graphql.org/swapi-graphql domains