### PR TITLE
feature: allow headers and methods for cross origin requests?

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -15,7 +15,13 @@ import swapiSchema from './schema/index';
 
 const app = express();
 
-app.use(cors({ origin: '*' }));
+app.use(
+  cors({
+    origin: '*',
+    methods: ['GET', 'PUT', 'POST', 'OPTIONS'],
+    allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept'],
+  }),
+);
 
 // Requests to /graphql redirect to /
 app.all('/graphql', (req, res) => res.redirect('/'));
@@ -31,6 +37,7 @@ app.get('/schema', (req, res) => {
     res.end();
   });
 });
+
 // octet-stream
 app.use('/schema.graphql', express.static('./schema.graphql'));
 


### PR DESCRIPTION
I think this will allow us to make cross domain requests from one netlify page to another? I'm able to request this from localhost. i had thought there were defaults for headers/methods already? bit confused

going to test it more locally with an /etc/hosts entry to see if i can recreate the scenario, if i cant locally then it might be something at the netlify level.