### PR TITLE
use latest release for cdn bundles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
     }
   </style>
   <link rel="icon" href="favicon.ico">
-  <link type="text/css" href="//unpkg.com/graphiql@0.17.0/graphiql.css" rel="stylesheet" />
+  <link type="text/css" href="//unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
 </head>
 <body>
   <div id="splash">
@@ -32,7 +32,7 @@
   <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
-  <script src="//unpkg.com/graphiql@0.17.0/graphiql.min.js"></script>
+  <script src="//unpkg.com/graphiql/graphiql.min.js"></script>
   <script>
       // Parse the search string to get url parameters.
       var search = window.location.search;


### PR DESCRIPTION
i think it issues a 301 or some such, so possibly a few 30-50ms extra roundtrip, but worth it to have the latest npm release always, no? maybe using the new min.css will make up for it?