### PR TITLE
chore: update swapi datasource, add swapi rest

### DIFF
--- a/handler/swapi.js
+++ b/handler/swapi.js
@@ -9,7 +9,7 @@
 
 const awsServerlessExpress = require('aws-serverless-express');
 
-const app = require('../lib/service');
+const app = require('../lib/swapi-rest');
 
 // NOTE: If you get ERR_CONTENT_DECODING_FAILED in your browser, this is likely
 // due to a compressed response (e.g. gzip) which has not been handled correctly

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -33,7 +33,7 @@ async function cacheResources() {
   const cache = {};
 
   for (const name of resources) {
-    let url = `https://swapi.co/api/${name}/`;
+    let url = `https://raw.githubusercontent.com/johnlindquist/swapi-json-server/master/${name}.json`;
 
     while (url != null) {
       console.error(url);

--- a/scripts/mocha-bootload.js
+++ b/scripts/mocha-bootload.js
@@ -1,10 +1,9 @@
 /**
- *  Copyright (c) 2015-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
  */
-
 process.env.NODE_ENV = 'test';

--- a/scripts/print-schema.js
+++ b/scripts/print-schema.js
@@ -1,10 +1,10 @@
 /**
- *  Copyright (c) 2015-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
  */
 
 import swapiSchema from '../src/schema';

--- a/scripts/serve-public.js
+++ b/scripts/serve-public.js
@@ -1,10 +1,10 @@
 /**
- *  Copyright (c) 2018-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
  */
 
 import express from 'express';

--- a/scripts/store-schema.js
+++ b/scripts/store-schema.js
@@ -1,19 +1,19 @@
 /**
- *  Copyright (c) 2015-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
  */
 
 import swapiSchema from '../src/schema';
 import { printSchema } from 'graphql/utilities';
-import { writeFileSync } from 'fs'
+import { writeFileSync } from 'fs';
 
 try {
   var output = printSchema(swapiSchema);
-  writeFileSync('schema.graphql', output, 'utf8')
+  writeFileSync('schema.graphql', output, 'utf8');
 } catch (error) {
   console.error(error);
   console.error(error.stack);

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,10 +1,10 @@
 /**
- *  Copyright (c) 2015-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
  */
 
 import sane from 'sane';

--- a/src/swapi-rest.js
+++ b/src/swapi-rest.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, GraphQL Contributors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE-examples file in the root directory of this source tree.
+ *
+ */
+
+const Express = require('express');
+
+const data = require('../cache/data.json');
+
+const resources = [
+  'people',
+  'starships',
+  'vehicles',
+  'species',
+  'planets',
+  'films',
+];
+
+const app = new Express();
+
+resources.forEach(r => {
+  app.get(`/api/${r}/`, (req, res, next) => {
+    if (!data || !data[r]) {
+      res.status(500);
+      res.error(`bad data, missing file or invalid swapi resource '${r}'`);
+    }
+    res.status(200);
+    res.json({ results: data[r] });
+    next();
+  });
+});
+
+module.exports = app;


### PR DESCRIPTION
* update swapi datasource. swapi.co seems gone. changed it to raw github json in a repo thats bene updated ~2yago at least
* add a swapi REST netlify demo, why not?
* some copyright changes, more soon