### PR TITLE
Update tests to match swapi.dev

### DIFF
--- a/src/schema/__tests__/apiHelper.js
+++ b/src/schema/__tests__/apiHelper.js
@@ -25,8 +25,8 @@ describe('API Helper', () => {
 
   it('Gets all pages at once', async () => {
     const { objects, totalCount } = await getObjectsByType('people');
-    expect(objects.length).to.equal(87);
-    expect(totalCount).to.equal(87);
+    expect(objects.length).to.equal(82);
+    expect(totalCount).to.equal(82);
     expect(objects[0].name).to.equal('Luke Skywalker');
   });
 

--- a/src/schema/__tests__/film.js
+++ b/src/schema/__tests__/film.js
@@ -99,7 +99,7 @@ describe('Film type', async () => {
       '{ allFilms { edges { cursor, node { ...AllFilmProperties } } } }',
     );
     const result = await swapi(query);
-    expect(result.data.allFilms.edges.length).to.equal(7);
+    expect(result.data.allFilms.edges.length).to.equal(6);
   });
 
   it('Pagination query', async () => {

--- a/src/schema/__tests__/person.js
+++ b/src/schema/__tests__/person.js
@@ -90,7 +90,7 @@ describe('Person type', async () => {
       skinColor: 'fair',
       homeworld: { name: 'Tatooine' },
       filmConnection: { edges: [{ node: { title: 'A New Hope' } }] },
-      species: { name: 'Human' },
+      species: null,
       starshipConnection: { edges: [{ node: { name: 'X-wing' } }] },
       vehicleConnection: { edges: [{ node: { name: 'Snowspeeder' } }] },
     };

--- a/src/schema/__tests__/person.js
+++ b/src/schema/__tests__/person.js
@@ -102,7 +102,7 @@ describe('Person type', async () => {
       '{ allPeople { edges { cursor, node { ...AllPersonProperties } } } }',
     );
     const result = await swapi(query);
-    expect(result.data.allPeople.edges.length).to.equal(87);
+    expect(result.data.allPeople.edges.length).to.equal(82);
   });
 
   it('Pagination query', async () => {

--- a/src/schema/__tests__/planet.js
+++ b/src/schema/__tests__/planet.js
@@ -98,7 +98,7 @@ describe('Planet type', async () => {
       '{ allPlanets { edges { cursor, node { ...AllPlanetProperties } } } }',
     );
     const result = await swapi(query);
-    expect(result.data.allPlanets.edges.length).to.equal(61);
+    expect(result.data.allPlanets.edges.length).to.equal(60);
   });
 
   it('Pagination query', async () => {

--- a/src/schema/__tests__/species.js
+++ b/src/schema/__tests__/species.js
@@ -88,7 +88,7 @@ describe('Species type', async () => {
       eyeColors: ['black'],
       hairColors: ['n/a'],
       homeworld: { name: 'Rodia' },
-      language: 'Galactic Basic',
+      language: 'Galatic Basic',
       name: 'Rodian',
       personConnection: { edges: [{ node: { name: 'Greedo' } }] },
       filmConnection: { edges: [{ node: { title: 'A New Hope' } }] },
@@ -122,7 +122,7 @@ describe('Species type', async () => {
     const nextResult = await swapi(nextQuery);
     expect(
       nextResult.data.allSpecies.edges.map(e => e.node.name),
-    ).to.deep.equal(['Wookiee', 'Rodian']);
+    ).to.deep.equal(['Wookie', 'Rodian']);
   });
 
   describe('Edge cases', () => {

--- a/src/schema/__tests__/starship.js
+++ b/src/schema/__tests__/starship.js
@@ -90,7 +90,7 @@ describe('Starship type', async () => {
       cargoCapacity: 1000000000000,
       consumables: '3 years',
       costInCredits: 1000000000000,
-      crew: '342953',
+      crew: '342,953',
       filmConnection: { edges: [{ node: { title: 'A New Hope' } }] },
       hyperdriveRating: 4,
       length: 120000,
@@ -101,7 +101,7 @@ describe('Starship type', async () => {
       maxAtmospheringSpeed: null,
       model: 'DS-1 Orbital Battle Station',
       name: 'Death Star',
-      passengers: '843342',
+      passengers: '843,342',
       pilotConnection: { edges: [] },
       starshipClass: 'Deep Space Mobile Battlestation',
     };

--- a/src/schema/__tests__/starship.js
+++ b/src/schema/__tests__/starship.js
@@ -113,7 +113,7 @@ describe('Starship type', async () => {
       '{ allStarships { edges { cursor, node { ...AllStarshipProperties } } } }',
     );
     const result = await swapi(query);
-    expect(result.data.allStarships.edges.length).to.equal(37);
+    expect(result.data.allStarships.edges.length).to.equal(36);
   });
 
   it('Pagination query', async () => {


### PR DESCRIPTION
Tests assertion values were little out of sync from what SWAPI returned so updated those values.

Note: Use `yarn cover` to run tests because `yarn test` fails at the moment because Flow is broken. Also `yarn coveralls` isn't working and will fix it once we switch to NPM #180 and update deps