### PR TITLE
fixing Netlify integration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   functions = "netlify-lambda-lib"
-  command = "npm run build"
+  command = "npm run download && npm run build"


### PR DESCRIPTION
This PR fixes the Netlify integration that currently fails when trying to use file `cache/data.json` in the build process. 

fixes #183 