### PR TITLE
enable all CORS

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -15,7 +15,7 @@ import swapiSchema from './schema/index';
 
 const app = express();
 
-app.use(cors({ origin: '*' }));
+app.use(cors());
 
 // Requests to /graphql redirect to /
 app.all('/graphql', (req, res) => res.redirect('/'));


### PR DESCRIPTION
following https://expressjs.com/en/resources/middleware/cors.html

not sure why though, CORS works with this same config for our default graphiql demo schema netlify function