### PR TITLE
specify CORS methods

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,4 @@
   for = "/graphql*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "POST, GET, OPTIONS"


### PR DESCRIPTION
currently the swapi-graphql itself works, but remote schema usage is still not working and returning 405. I think adding POST and OPTIONS methods to the netlify config will fix this