### PR TITLE
Handle redirects in other routes

### DIFF
--- a/handler/index.mjs
+++ b/handler/index.mjs
@@ -2,6 +2,9 @@
  * 301 permanently redirect /index requests to /graphql
  */
 export const handler = async function(event) {
+  if (req.httpMethod === 'OPTIONS') {
+    return { statusCode: 200 }
+  }
   let location = '/graphql';
   if (event.queryStringParameters) {
     location += '?' + new URLSearchParams(event.queryStringParameters);

--- a/handler/index.mjs
+++ b/handler/index.mjs
@@ -3,7 +3,7 @@
  */
 export const handler = async function(event) {
   if (req.httpMethod === 'OPTIONS') {
-    return { statusCode: 200 }
+    return { statusCode: 200 };
   }
   let location = '/graphql';
   if (event.queryStringParameters) {

--- a/handler/swapi.mjs
+++ b/handler/swapi.mjs
@@ -2,6 +2,9 @@
  * 301 permanently redirect /swapi requests to /graphql
  */
 export const handler = async function(event) {
+  if (req.httpMethod === 'OPTIONS') {
+    return { statusCode: 200 }
+  }
   let location = '/graphql';
   if (event.queryStringParameters) {
     location += '?' + new URLSearchParams(event.queryStringParameters);

--- a/handler/swapi.mjs
+++ b/handler/swapi.mjs
@@ -3,7 +3,7 @@
  */
 export const handler = async function(event) {
   if (req.httpMethod === 'OPTIONS') {
-    return { statusCode: 200 }
+    return { statusCode: 200 };
   }
   let location = '/graphql';
   if (event.queryStringParameters) {


### PR DESCRIPTION
Currently the graphql site reaches out to this URL and will be redirected. However the OPTIONS request will fail as that can't be redirected so to do this successfully we'll need to combine this with a successful options request.