### PR TITLE
Bump graphql-http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "babel-runtime": "^6.26.0",
         "dataloader": "1.4.0",
         "graphql": "14.5.8",
-        "graphql-http": "^1.21.0",
+        "graphql-http": "^1.22.4",
         "graphql-relay": "0.6.0"
       },
       "devDependencies": {
@@ -4472,9 +4472,9 @@
       }
     },
     "node_modules/graphql-http": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.21.0.tgz",
-      "integrity": "sha512-yrItPfHj5WeT4n7iusbVin+vGSQjXFAX6U/GnYytdCJRXVad1TWGtYFDZ2ROjCKpXQzIwvfbiWCEwfuXgR3B6A==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-runtime": "^6.26.0",
     "dataloader": "1.4.0",
     "graphql": "14.5.8",
-    "graphql-http": "^1.21.0",
+    "graphql-http": "^1.22.4",
     "graphql-relay": "0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes our missing headers, which is fixed in https://github.com/graphql/graphql-http/commit/cd1523f261946b97f0237444802fea760752b767