### PR TITLE
Fix SWAPI, pin graphiql versions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8" />
   <meta name="robots" content="noindex" />
@@ -30,10 +29,10 @@
   <link rel="stylesheet" href="https://esm.sh/@graphiql/plugin-explorer@5.1.1/dist/style.css"
     integrity="sha384-vTFGj0krVqwFXLB7kq/VHR0/j2+cCT/B63rge2mULaqnib2OX7DVLUVksTlqvMab" crossorigin="anonymous" />
   <!--
-     * Note:
-     * The ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file.
-     * `@emotion/is-prop-valid` is a shim to remove the console error ` module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126
-    -->
+    * Note:
+    * The ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file.
+    * `@emotion/is-prop-valid` is a shim to remove the console error ` module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126
+  -->
   <script type="importmap">
     {
       "imports": {
@@ -77,7 +76,7 @@
     search
       .substr(1)
       .split('&')
-      .forEach(function (entry) {
+      .forEach(function(entry) {
         var eq = entry.indexOf('=');
         if (eq >= 0) {
           parameters[decodeURIComponent(entry.slice(0, eq))] =
@@ -120,10 +119,10 @@
       var newSearch =
         '?' +
         Object.keys(parameters)
-          .filter(function (key) {
+          .filter(function(key) {
             return Boolean(parameters[key]);
           })
-          .map(function (key) {
+          .map(function(key) {
             return (
               encodeURIComponent(key) +
               '=' +
@@ -159,11 +158,9 @@
     root.render(React.createElement(App));
   </script>
 </head>
-
 <body>
-  <div id="graphiql">
-    <div class="loading">Loading…</div>
-  </div>
+<div id="graphiql">
+  <div class="loading">Loading…</div>
+</div>
 </body>
-
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="robots" content="noindex" />
@@ -24,134 +25,145 @@
     }
   </style>
   <link rel="icon" href="favicon.ico" />
-  <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
-  <link
-    rel="stylesheet"
-    href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
-  />
-  <!-- Note: the ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file. -->
-  <!-- `@emotion/is-prop-valid` is a shim to remove the console error `module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126 -->
+  <link rel="stylesheet" href="https://esm.sh/graphiql@5.2.2/dist/style.css"
+    integrity="sha384-f6GHLfCwoa4MFYUMd3rieGOsIVAte/evKbJhMigNdzUf52U9bV2JQBMQLke0ua+2" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://esm.sh/@graphiql/plugin-explorer@5.1.1/dist/style.css"
+    integrity="sha384-vTFGj0krVqwFXLB7kq/VHR0/j2+cCT/B63rge2mULaqnib2OX7DVLUVksTlqvMab" crossorigin="anonymous" />
+  <!--
+     * Note:
+     * The ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file.
+     * `@emotion/is-prop-valid` is a shim to remove the console error ` module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126
+    -->
   <script type="importmap">
     {
       "imports": {
-        "react": "https://esm.sh/react@19.1.0",
-        "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
-
-        "react-dom": "https://esm.sh/react-dom@19.1.0",
-        "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
-        "@emotion/is-prop-valid": "data:text/javascript,",
-
-        "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
-        "graphiql/": "https://esm.sh/graphiql/",
-        "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
-        "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql,@emotion/is-prop-valid",
-
-        "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
-        "graphql": "https://esm.sh/graphql@16.11.0"
+        "react": "https://esm.sh/react@19.2.5",
+        "react/": "https://esm.sh/react@19.2.5/",
+        "react-dom": "https://esm.sh/react-dom@19.2.5",
+        "react-dom/": "https://esm.sh/react-dom@19.2.5/",
+        "graphiql": "https://esm.sh/graphiql@5.2.2?standalone&external=react,react-dom,@graphiql/react,graphql",
+        "graphiql/": "https://esm.sh/graphiql@5.2.2/",
+        "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer@5.1.1?standalone&external=react,@graphiql/react,graphql",
+        "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.3?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
+        "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit@0.11.3?standalone&external=graphql",
+        "graphql": "https://esm.sh/graphql@16.13.2",
+        "@emotion/is-prop-valid": "data:text/javascript,"
+      },
+      "integrity": {
+        "https://esm.sh/react@19.2.5": "sha384-ZNmUQ9QQgyl95nnD/FJTBQn2ZEPTbWtMuWCXTKWNuF6Si7nC+6bvSgk5LWu+ELHn",
+        "https://esm.sh/react-dom@19.2.5": "sha384-qtNxBzn9gBs3CmJItMuvIVyjW3VIU0/rzGhCm9MippVU1BpR/c4VgaFYDIg/FrY2",
+        "https://esm.sh/graphiql@5.2.2": "sha384-MBVZMq1pmz8DwpwIWPWLk2tmS6tGiSi6WwbXvy9NhuDYASAAWd2m96xbxLqszig9",
+        "https://esm.sh/graphiql@5.2.2?standalone&external=react,react-dom,@graphiql/react,graphql": "sha384-SzHBEbcQfhvmwqh5Vtat9k7b/kIzmdVO3KMzQiAYwcxCA9x7vZwFRUgjzN1AeV3q",
+        "https://esm.sh/@graphiql/plugin-explorer@5.1.1": "sha384-83REbLb9KtIhL/6J1n91SLoP0648KOKZLIDdHRx/a0E7T3ajq6PzKz+815SCfN52",
+        "https://esm.sh/@graphiql/react@0.37.3?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid": "sha384-iZsbTy9B0VcX2BOTdqMuX0uJ9Hff5GbG2QeOt4OeMp0GHza76dwQaYQYNYkZkIVq",
+        "https://esm.sh/@graphiql/toolkit@0.11.3?standalone&external=graphql": "sha384-ZsnupyYmzpNjF1Z/81zwi4nV352n4P7vm0JOFKiYnAwVGOf9twnEMnnxmxabMBXe",
+        "https://esm.sh/graphql@16.13.2": "sha384-TQg9alwG3P9fzBErDW011vKuyTnrwpBZsl3SdMAh6DwBcv9ezFOl0djGI/68VOyy"
       }
     }
   </script>
-<script type="module">
-  // Import React and ReactDOM
-  import React from 'react';
-  import ReactDOM from 'react-dom/client';
-  // Import GraphiQL and the Explorer plugin
-  import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
-  import { createGraphiQLFetcher } from '@graphiql/toolkit';
-  import { explorerPlugin } from '@graphiql/plugin-explorer';
-  import 'graphiql/setup-workers/esm.sh';
+  <script type="module">
+    // Import React and ReactDOM
+    import React from 'react';
+    import ReactDOM from 'react-dom/client';
+    // Import GraphiQL and the Explorer plugin
+    import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+    import { createGraphiQLFetcher } from '@graphiql/toolkit';
+    import { explorerPlugin } from '@graphiql/plugin-explorer';
+    import 'graphiql/setup-workers/esm.sh';
 
-  // Parse the search string to get url parameters.
-  var search = window.location.search;
-  var parameters = {};
-  search
-    .substr(1)
-    .split('&')
-    .forEach(function(entry) {
-      var eq = entry.indexOf('=');
-      if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-          decodeURIComponent(entry.slice(eq + 1));
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search
+      .substr(1)
+      .split('&')
+      .forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
+
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables = JSON.stringify(
+          JSON.parse(parameters.variables),
+          null,
+          2,
+        );
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
       }
-    });
-
-  // if variables was provided, try to format it.
-  if (parameters.variables) {
-    try {
-      parameters.variables = JSON.stringify(
-        JSON.parse(parameters.variables),
-        null,
-        2,
-      );
-    } catch (e) {
-      // Do nothing, we want to display the invalid JSON as a string, rather
-      // than present an error.
     }
-  }
 
-  // When the query and variables string is edited, update the URL bar so
-  // that it can be easily shared
-  function onEditQuery(newQuery) {
-    parameters.query = newQuery;
-    updateURL();
-  }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
 
-  function onEditVariables(newVariables) {
-    parameters.variables = newVariables;
-    updateURL();
-  }
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
 
-  function onEditOperationName(newOperationName) {
-    parameters.operationName = newOperationName;
-    updateURL();
-  }
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
 
-  function updateURL() {
-    var newSearch =
-      '?' +
-      Object.keys(parameters)
-        .filter(function(key) {
-          return Boolean(parameters[key]);
-        })
-        .map(function(key) {
-          return (
-            encodeURIComponent(key) +
-            '=' +
-            encodeURIComponent(parameters[key])
-          );
-        })
-        .join('&');
-    history.replaceState(null, null, newSearch);
-  }
+    function updateURL() {
+      var newSearch =
+        '?' +
+        Object.keys(parameters)
+          .filter(function (key) {
+            return Boolean(parameters[key]);
+          })
+          .map(function (key) {
+            return (
+              encodeURIComponent(key) +
+              '=' +
+              encodeURIComponent(parameters[key])
+            );
+          })
+          .join('&');
+      history.replaceState(null, null, newSearch);
+    }
 
-  const fetcher = createGraphiQLFetcher({
-    url:
-      parameters.fetchURL ||
-      '/graphql',
-  });
-  const plugins = [HISTORY_PLUGIN, explorerPlugin()];
-
-  function App() {
-    return React.createElement(GraphiQL, {
-      fetcher: fetcher,
-      initialQuery: parameters.query,
-      initialVariables: parameters.variables,
-      operationName: parameters.operationName,
-      onEditQuery: onEditQuery,
-      onEditVariables: onEditVariables,
-      onEditOperationName: onEditOperationName,
-      plugins,
+    const fetcher = createGraphiQLFetcher({
+      url:
+        parameters.fetchURL ||
+        '/graphql',
     });
-  }
+    const plugins = [HISTORY_PLUGIN, explorerPlugin()];
 
-  const container = document.getElementById('graphiql');
-  const root = ReactDOM.createRoot(container);
-  root.render(React.createElement(App));
-</script>
+    function App() {
+      return React.createElement(GraphiQL, {
+        fetcher: fetcher,
+        initialQuery: parameters.query,
+        initialVariables: parameters.variables,
+        operationName: parameters.operationName,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        plugins,
+      });
+    }
+
+    const container = document.getElementById('graphiql');
+    const root = ReactDOM.createRoot(container);
+    root.render(React.createElement(App));
+  </script>
 </head>
+
 <body>
-<div id="graphiql">
-  <div class="loading">Loading…</div>
-</div>
+  <div id="graphiql">
+    <div class="loading">Loading…</div>
+  </div>
 </body>
+
 </html>


### PR DESCRIPTION
The recent release of graphiql inadvertently broke the CDN example, which this repo uses, due to an upstream change in esm.sh's bundling strategy.

This change updates to our most recent working version of the CDN example, notably pinning the graphiql version to the most recent known good version while we try to resolve the issue upstream.

Recommend reviewing [with whitespace hidden](https://github.com/graphql/swapi-graphql/pull/250/changes?w=1).

Ref: https://github.com/graphql/graphiql/issues/4303